### PR TITLE
Cross-platform support

### DIFF
--- a/install.js
+++ b/install.js
@@ -22,7 +22,7 @@ module.exports = {
         },
         path: "applio",
         message: [
-          "python.exe -m pip install pip<24.1",
+          "python -m pip install pip<24.1",
           "pip install --upgrade setuptools",
           "pip install -r requirements.txt",
           "pip uninstall torch torchvision torchaudio -y",

--- a/install.js
+++ b/install.js
@@ -3,37 +3,29 @@ module.exports = {
     {
       method: "shell.run",
       params: {
-        message: ["git clone https://github.com/IAHispano/Applio applio"],
+        message: "git clone https://github.com/IAHispano/Applio applio",
       },
+    },
+    {
+      method: "script.start",
+      params: {
+        uri: "torch.js",
+          params: {
+          venv: "env",               
+          path: "applio",
+        }
+      }
     },
     {
       method: "shell.run",
       params: {
-        path: "applio",
-        message: ["conda create --no-shortcuts -y -k --prefix env python=3.9"],
-      },
-    },
-    {
-      method: "shell.run",
-      params: {
-        conda: {
-          path: "env",
-          python: "python=3.9",
-        },
-        path: "applio",
+        venv: "env",                // Edit this to customize the venv folder path
+        path: "applio",                // Edit this to customize the path to start the shell from
         message: [
-          "python -m pip install pip<24.1",
           "pip install --upgrade setuptools",
-          "pip install -r requirements.txt",
-          "pip uninstall torch torchvision torchaudio -y",
-        ],
-      },
-    },
-    {
-      method: "notify",
-      params: {
-        html: "Click the 'start' tab to get started!",
-      },
-    },
-  ],
-};
+          "pip install -r ../requirements.txt",
+        ]
+      }
+    }
+  ]
+}

--- a/install.js
+++ b/install.js
@@ -26,7 +26,6 @@ module.exports = {
           "pip install --upgrade setuptools",
           "pip install -r requirements.txt",
           "pip uninstall torch torchvision torchaudio -y",
-          "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121",
         ],
       },
     },

--- a/pinokio.js
+++ b/pinokio.js
@@ -10,6 +10,7 @@ module.exports = {
     let running = await kernel.running(__dirname, "start.js")
     if (installing) {
       return [{
+        default: true,
         icon: "fa-solid fa-plug",
         text: "Installing",
         href: "install.js",
@@ -19,6 +20,7 @@ module.exports = {
         let local = kernel.memory.local[path.resolve(__dirname, "start.js")]
         if (local && local.url) {
           return [{
+            default: true,
             icon: "fa-solid fa-rocket",
             text: "Open Web UI",
             href: local.url,
@@ -29,6 +31,7 @@ module.exports = {
           }]
         } else {
           return [{
+            default: true,
             icon: 'fa-solid fa-terminal',
             text: "Terminal",
             href: "start.js",
@@ -36,6 +39,7 @@ module.exports = {
         }
       } else {
         return [{
+          default: true,
           icon: "fa-solid fa-power-off",
           text: "Start",
           href: "start.js",
@@ -55,6 +59,7 @@ module.exports = {
       }
     } else {
       return [{
+        default: true,
         icon: "fa-solid fa-plug",
         text: "Install",
         href: "install.js",

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ tensorboard
 gradio==4.43.0
 
 # Miscellaneous utilities
-certifi==2024.7.4; sys_platform == 'darwin'
+certifi==2023.7.22; sys_platform == 'darwin'
 antlr4-python3-runtime==4.8; sys_platform == 'darwin'
 ffmpy==0.3.1
 tensorboardX

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,53 @@
+# Core dependencies
+pip==23.3; sys_platform == 'darwin'
+wheel; sys_platform == 'darwin'
+PyYAML; sys_platform == 'darwin'
+numpy==1.23.5
+requests==2.32.0
+tqdm
+wget
+pydantic==2.8.2
+fastapi==0.112.0
+starlette==0.37.2
+
+# Audio processing
+ffmpeg-python>=0.2.0
+faiss-cpu==1.7.3
+librosa==0.9.2
+pyworld==0.3.4
+scipy==1.11.1
+soundfile==0.12.1
+praat-parselmouth
+noisereduce
+versatile-audio-upscaler
+pedalboard
+stftpitchshift
+
+# Machine learning and deep learning
+omegaconf; sys_platform == 'darwin'
+numba; sys_platform == 'linux'
+numba==0.57.0; sys_platform == 'darwin' or sys_platform == 'win32'
+# torch==2.1.1
+# torchaudio==2.1.1
+# torchvision==0.16.1
+torchcrepe==0.0.23
+torchfcpe
+einops
+libf0
+transformers==4.44.2
+
+# Visualization and UI
+matplotlib==3.7.2
+tensorboard
+gradio==4.43.0
+
+# Miscellaneous utilities
+certifi==2024.7.4; sys_platform == 'darwin'
+antlr4-python3-runtime==4.8; sys_platform == 'darwin'
+ffmpy==0.3.1
+tensorboardX
+edge-tts==6.1.9
+pypresence
+beautifulsoup4
+flask
+local-attention

--- a/start.js
+++ b/start.js
@@ -5,9 +5,7 @@ module.exports = {
       id: "start",
       method: "shell.run",
       params: {
-        conda: {
-          path: "env",
-        },
+        venv: "env",
         path: "applio",
         message: [
           "python app.py",
@@ -29,12 +27,6 @@ module.exports = {
       params: {
         uri: "{{local.url}}",
         name: "Local Sharing"
-      }
-    },
-    {
-      method: "notify",
-      params: {
-        html: "Click the 'Open Web UI' button to open the web interface",
       }
     }
   ]

--- a/start.js
+++ b/start.js
@@ -6,6 +6,9 @@ module.exports = {
       method: "shell.run",
       params: {
         venv: "env",
+        env: {
+          PYTORCH_ENABLE_MPS_FALLBACK: 1
+        },
         path: "applio",
         message: [
           "python app.py",

--- a/torch.js
+++ b/torch.js
@@ -6,7 +6,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
       }
     },
     // windows amd
@@ -26,7 +26,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cpu"
       }
     },
     // mac
@@ -36,7 +36,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cpu"
       }
     },
     // linux nvidia
@@ -46,7 +46,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
       }
     },
     // linux rocm (amd)
@@ -56,7 +56,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/rocm5.6"
       }
     },
     // linux cpu
@@ -66,7 +66,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+        "message": "pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cpu"
       }
     }
   ]

--- a/torch.js
+++ b/torch.js
@@ -1,0 +1,73 @@
+module.exports = {
+  run: [
+    {
+      "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
+      }
+    },
+    // windows amd
+    {
+      "when": "{{platform === 'win32' && gpu === 'amd'}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch-directml torchaudio torchvision numpy==1.23.5"
+      }
+    },
+    // windows cpu
+    {
+      "when": "{{platform === 'win32' && (gpu !== 'nvidia' && gpu !== 'amd')}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch torchvision torchaudio"
+      }
+    },
+    // mac
+    {
+      "when": "{{platform === 'darwin'}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu"
+      }
+    },
+    // linux nvidia
+    {
+      "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}"
+      }
+    },
+    // linux rocm (amd)
+    {
+      "when": "{{platform === 'linux' && gpu === 'amd'}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7"
+      }
+    },
+    // linux cpu
+    {
+      "when": "{{platform === 'linux' && (gpu !== 'amd' && gpu !=='amd')}}",
+      "method": "shell.run",
+      "params": {
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Switched to venv
- Added requirements.txt
- Commented out torch and added the torch.js script for crossplatform support
- Removed omegaconf version to avoid the metadata error
- Changed the certifi version to 2023.7.22 for Macs, since certifi 2024.7.4 is not compatible with edge-tts 6.1.9
- Added mps fallback variable in start.js
- Added autolaunch function in piokio.js